### PR TITLE
(Windows) Move .mo files to "share" subdir under python root dir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ import shutil
 import subprocess
 import sys
 import unittest
+import platform
 
 from PyQt5 import uic
 from PyQt5.Qt import PYQT_VERSION_STR
@@ -241,6 +242,7 @@ class InstallLocale(install_data):
     def run(self):
         print("COMPILING PO FILES")
         i18nfiles = []
+        is_windows = platform.system() == 'Windows'
         if not os.path.isdir("src/openmolar/locale/"):
             print("WARNING - language files are missing!")
         for po_file in glob.glob("src/openmolar/locale/*.po"):
@@ -249,6 +251,9 @@ class InstallLocale(install_data):
             mo_dir = os.path.join(directory, lang)
             try:
                 os.mkdir(mo_dir)
+                if is_windows:
+                    mo_dir = os.path.join(mo_dir, "LC_MESSAGES")
+                    os.mkdir(mo_dir)
             except OSError:
                 pass
             mo_file = os.path.join(mo_dir, "openmolar.mo")
@@ -258,8 +263,11 @@ class InstallLocale(install_data):
                 if os.system(cmd) != 0:
                     info('Error while running msgfmt on %s' % po_file)
 
-            destdir = os.path.join("/usr", "share", "locale", lang,
-                                   "LC_MESSAGES")
+            destdir = os.path.join("share", "locale", lang)
+            if is_windows:
+                destdir = os.path.join(destdir, "LC_MESSAGES")
+            else:
+                destdir = os.path.join("/usr", destdir)
 
             i18nfiles.append((destdir, [mo_file]))
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,10 @@ from openmolar.settings import version
 
 VERSION = version.VERSION
 RESOURCE_FILE = os.path.join(OM_PATH, "openmolar", "qt4gui", "resources_rc.py")
+IS_WINDOWS = platform.system() == 'Windows'
+USR = ""
+if not IS_WINDOWS:
+    USR = "/usr/"
 
 
 def version_fixes(pydata):
@@ -242,7 +246,6 @@ class InstallLocale(install_data):
     def run(self):
         print("COMPILING PO FILES")
         i18nfiles = []
-        is_windows = platform.system() == 'Windows'
         if not os.path.isdir("src/openmolar/locale/"):
             print("WARNING - language files are missing!")
         for po_file in glob.glob("src/openmolar/locale/*.po"):
@@ -251,7 +254,7 @@ class InstallLocale(install_data):
             mo_dir = os.path.join(directory, lang)
             try:
                 os.mkdir(mo_dir)
-                if is_windows:
+                if IS_WINDOWS:
                     mo_dir = os.path.join(mo_dir, "LC_MESSAGES")
                     os.mkdir(mo_dir)
             except OSError:
@@ -264,7 +267,7 @@ class InstallLocale(install_data):
                     info('Error while running msgfmt on %s' % po_file)
 
             destdir = os.path.join("share", "locale", lang)
-            if is_windows:
+            if IS_WINDOWS:
                 destdir = os.path.join(destdir, "LC_MESSAGES")
             else:
                 destdir = os.path.join("/usr", destdir)
@@ -334,9 +337,9 @@ setup(
                                 'html/images/*.*',
                                 'html/firstrun/*.*', ]},
     data_files=[
-        ('/usr/share/man/man1', ['bin/openmolar.1']),
-        ('/usr/share/icons/hicolor/scalable/apps', ['bin/openmolar.svg']),
-        ('/usr/share/applications', ['bin/openmolar.desktop']), ],
+        (USR + 'share/man/man1', ['bin/openmolar.1']),
+        (USR + 'share/icons/hicolor/scalable/apps', ['bin/openmolar.svg']),
+        (USR + 'share/applications', ['bin/openmolar.desktop']), ],
     cmdclass={'sdist': Sdist,
               'clean': Clean,
               'build': Build,


### PR DESCRIPTION
Move the .mo files to the $PYTHONDIR/share subdir when installing openmolar on Windows, so that the translations work without much effort (also, on windows, the user can set the LANG environment variable to change the language easily). I'm not really sure if this is correct, or a good idea, though...
This comes from the realization that gettext.bindtextdomain('openmolar') returns this path under Windows, while it returns '/usr/share/locale' in Linux.